### PR TITLE
Added Metar to Simbrief Briefing

### DIFF
--- a/resources/views/layouts/Disposable_v3/flights/simbrief_briefing_info.blade.php
+++ b/resources/views/layouts/Disposable_v3/flights/simbrief_briefing_info.blade.php
@@ -244,6 +244,19 @@
         </div>
       </div>
     </div>
+        {{-- Row : Metar --}}
+    <div class="row row-cols-lg-2">
+        <div class="col-lg">
+            <div class="card p-0 mb-2 bg-transparent">
+            <iframe style="pointer-events: none; border-radius: 5px;" src="https://metar-taf.com/embed/{{ $simbrief->xml->origin->icao_code }}?bg_color=1f0dc0e6&layout=landscape" frameBorder="0" width="100%" height="256" scrolling="no"></iframe>
+            </div>
+        </div>
+        <div class="col-lg">
+            <div class="card p-0 mb-2 bg-transparent">
+            <iframe style="pointer-events: none; border-radius: 5px;" src="https://metar-taf.com/embed/{{ $simbrief->xml->destination->icao_code }}?bg_color=1f0dc0e6&layout=landscape" frameBorder="0" width="100%" height="256" scrolling="no"></iframe>
+            </div>
+        </div>
+    </div>
   </div>
   @php
     $crew_count = 0;


### PR DESCRIPTION
Added a Metar for the Simbrief Briefing page from METAR-TAF.com, similar to the one on the front page.